### PR TITLE
Enhance CI workflow for GitHub Release and PyPI publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,12 @@ jobs:
   build-release-publish:
     name: Build and Create Github Release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC for PyPI
+      contents: write  # For GitHub Release
+    environment:
+      name: pypi
+      url: https://pypi.org/p/${{ github.event.repository.name }}
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:


### PR DESCRIPTION
- Added permissions for id-token and contents to facilitate OIDC for PyPI and GitHub Release creation.
- Defined the environment for PyPI with the appropriate URL, improving clarity and organization in the workflow.

These changes streamline the release process and ensure proper permissions are set for publishing.