### PR TITLE
Fix version output format in CI workflow for GitHub Actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           VERSION=$(poetry version -s)
           echo "Found version: ${VERSION}"
-          echo "version=v${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build package
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phantom-core"
-version = "0.0.4"
+version = "0.0.5"
 description = "Phantom Core"
 authors = ["Adam Lineberry <ablineberry@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Updated the version output in the publish workflow to remove the 'v' prefix, ensuring consistency with the expected format for versioning. This change enhances the clarity of the version information passed to GitHub Actions, improving the overall reliability of the release process.