### PR TITLE
Update CI workflow name to reflect publishing to PyPI and GitHub Release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-release-publish:
-    name: Build and Create Github Release
+    name: Build, Publish to PyPI, and Create Github Release
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # OIDC for PyPI

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,36 +63,3 @@ jobs:
             dist/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
-      
-
-  # publish:
-  #   name: Publish to PyPI
-  #   needs: [build-and-release]
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: pypi
-  #     url: https://pypi.org/p/${{ github.event.repository.name }}
-  #   permissions:
-  #     id-token: write  # OIDC for PyPI
-  #     contents: write  # For GitHub Release
-  #   steps:
-  #     - uses: actions/checkout@v4
-      
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v4
-  #       with:
-  #         python-version: "3.x"
-      
-  #     - name: Install Poetry
-  #       run: pipx install poetry
-      
-  #     - name: Build package
-  #       run: poetry build
-      
-      
-  #     - name: Create GitHub Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         tag_name: ${{ needs.create-tag.outputs.version }}
-  #         generate_release_notes: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "phantom-core"
-version = "0.0.5"
+version = "0.0.6"
 description = "Phantom Core"
 authors = ["Adam Lineberry <ablineberry@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Modified the job name in the publish workflow to clarify that it now includes both publishing to PyPI and creating a GitHub Release. This change enhances the readability and understanding of the workflow's purpose, aligning it with the overall release process.